### PR TITLE
Merge rawflashdump-dev into main

### DIFF
--- a/Flash.cs
+++ b/Flash.cs
@@ -1,23 +1,24 @@
-﻿using Microsoft.Win32.SafeHandles;
-using System;
+﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace QuantumTunnel
 {
-    public static class FlashFS
+    internal static class Flash
     {
-        private static readonly string FlashDeviceName = "\\\\.\\Xvuc\\FlashFs";
-        
-        public static void ReadFile(string name)
+        private static readonly string RawFlashDeviceName = "\\\\.\\Xvuc\\Flash";
+
+        public static bool DumpFlashImage(string DumpToPath)
         {
-            string fullpath = FlashDeviceName + "\\" + name;
-            IntPtr FileHandle = KernelBase.CreateFile(fullpath, System.IO.FileAccess.Read, System.IO.FileShare.None, IntPtr.Zero, System.IO.FileMode.Open, System.IO.FileAttributes.Normal, IntPtr.Zero);
+            IntPtr FileHandle = IntPtr.Zero;
+            FileHandle = KernelBase.CreateFile(RawFlashDeviceName, System.IO.FileAccess.Read, System.IO.FileShare.None, IntPtr.Zero, System.IO.FileMode.Open, System.IO.FileAttributes.Normal, IntPtr.Zero);
+            if(FileHandle == IntPtr.Zero)
+            {
+                return false;
+            }
             FileStream FlashStream = new FileStream(FileHandle, FileAccess.Read);
             byte[] b = null;
             using (MemoryStream ms = new MemoryStream())
@@ -30,9 +31,10 @@ namespace QuantumTunnel
                     ms.Write(buf, 0, count);
                 } while (FlashStream.CanRead && count > 0);
                 b = ms.ToArray();
-                File.WriteAllBytes(name, b);
+                File.WriteAllBytes(DumpToPath, b);
             }
-        }
+            return true;
 
+        }
     }
 }

--- a/Flash.cs
+++ b/Flash.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -19,22 +19,20 @@ namespace QuantumTunnel
             {
                 return false;
             }
-            FileStream FlashStream = new FileStream(FileHandle, FileAccess.Read);
-            byte[] b = null;
-            using (MemoryStream ms = new MemoryStream())
+            ;
+            using (FileStream fsFlash = new FileStream(FileHandle, FileAccess.Read))
+            using (FileStream fsOutputFile = new FileStream(DumpToPath, FileMode.Create, FileAccess.Write))
             {
                 int count = 0;
+                byte[] buf = new byte[1024 * 1024]; // 1MB
                 do
                 {
-                    byte[] buf = new byte[1024];
-                    count = FlashStream.Read(buf, 0, 1024);
-                    ms.Write(buf, 0, count);
-                } while (FlashStream.CanRead && count > 0);
-                b = ms.ToArray();
-                File.WriteAllBytes(DumpToPath, b);
+                    count = fsFlash.Read(buf, 0, buf.Length);
+                    fsOutputFile.Write(buf, 0, count);
+                    total -=  count;
+                } while (fsFlash.CanRead && count > 0);
             }
             return true;
-
         }
     }
 }

--- a/FlashFS.cs
+++ b/FlashFS.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Win32.SafeHandles;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
@@ -7,6 +6,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 
 namespace QuantumTunnel
 {
@@ -14,25 +14,29 @@ namespace QuantumTunnel
     {
         private static readonly string FlashDeviceName = "\\\\.\\Xvuc\\FlashFs";
         
-        public static void ReadFile(string name)
+        public static bool ReadFile(string name)
         {
             string fullpath = FlashDeviceName + "\\" + name;
-            IntPtr FileHandle = KernelBase.CreateFile(fullpath, System.IO.FileAccess.Read, System.IO.FileShare.None, IntPtr.Zero, System.IO.FileMode.Open, System.IO.FileAttributes.Normal, IntPtr.Zero);
-            FileStream FlashStream = new FileStream(FileHandle, FileAccess.Read);
-            byte[] b = null;
-            using (MemoryStream ms = new MemoryStream())
+            IntPtr pHandle = KernelBase.CreateFile(fullpath, System.IO.FileAccess.Read, System.IO.FileShare.None, IntPtr.Zero, System.IO.FileMode.Open, System.IO.FileAttributes.Normal, IntPtr.Zero);
+            if(pHandle == IntPtr.Zero)
+            {
+                return false;
+            }
+            // Wrap the raw ptr into self-disposing handle
+            SafeFileHandle hFlashFile = new SafeFileHandle(pHandle, true);
+
+            using (FileStream fsFlashFile = new FileStream(hFlashFile, FileAccess.Read))
+            using (FileStream fsOutputFile = new FileStream(name, FileMode.Create, FileAccess.Write))
             {
                 int count = 0;
+                byte[] buf = new byte[1024]; // 1KB
                 do
                 {
-                    byte[] buf = new byte[1024];
-                    count = FlashStream.Read(buf, 0, 1024);
-                    ms.Write(buf, 0, count);
-                } while (FlashStream.CanRead && count > 0);
-                b = ms.ToArray();
-                File.WriteAllBytes(name, b);
+                    count = fsFlashFile.Read(buf, 0, 1024);
+                    fsOutputFile.Write(buf, 0, count);
+                } while (fsFlashFile.CanRead && count > 0);
             }
+            return true;
         }
-
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
 
 namespace QuantumTunnel
 {
@@ -9,8 +11,22 @@ namespace QuantumTunnel
             Console.WriteLine("QuantumTunnel - C# FlashFS Reader");
             if(args.Length == 0)
             {
-                Console.WriteLine("Provide name of file on flash. Example: certkeys.bin");
-                Environment.Exit(-1);
+                Console.WriteLine("Provide name of file on flash. Example: certkeys.bin OR -rawdump to obtain a raw image of the flash, named flash.bin.");
+                Environment.Exit(1);
+            }
+            if(args[0].ToLower() == "-rawdump")
+            {
+                Console.WriteLine("Dumping raw flash image, this will take a while...");
+                if (Flash.DumpFlashImage("flash.bin"))
+                {
+                    Console.WriteLine("Dumped flash to flash.bin");
+                    Environment.Exit(0);
+                }
+                else
+                {
+                    Console.WriteLine($"An error occured, do you have privileges? Error: {new Win32Exception(Marshal.GetLastWin32Error()).Message}");
+                    Environment.Exit(1);
+                }
             }
             string filename = args[0];
             FlashFS.ReadFile(filename);


### PR DESCRIPTION
Add -rawdump parameter, which produces a raw binary image of the flash from \\.\Xvuc\Flash. Will be compatible with XBFS tools once EOF issue is sorted.