### PR TITLE
ci: Do not trim built binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         path: bin/Release/net7.0/*
 
     - name: Build (standalone)
-      run: dotnet publish -c Release --self-contained -r win-x64 -p:PublishTrimmed=true -p:PublishSingleFile=true
+      run: dotnet publish -c Release --self-contained -r win-x64 -p:PublishSingleFile=true
     - name: Prepare standalone release
       run: |
         mkdir release


### PR DESCRIPTION
Fixes this bug with CommandLineParser dependency by not trimming the published binary.

```
QuantumTunnel.exe
QuantumTunnel - C# FlashFS Reader
Unhandled exception. System.InvalidOperationException: Type QuantumTunnel.CommandLineOptions appears to be immutable, but no constructor found to accept values.
at CommandLine.Core.InstanceBuilder.BuildImmutable[T](Type, Maybe1, IEnumerable1, IEnumerable1, List1)
at CommandLine.Core.InstanceBuilder.<>c__DisplayClass0_01.<Build>b__5() at CommandLine.Core.InstanceBuilder.Build[T](Maybe1, Func3, IEnumerable1, StringComparer, Boolean, CultureInfo, Boolean, Boolean, IEnumerable1) at CommandLine.Parser.ParseArguments[T](IEnumerable1)
at QuantumTunnel.QuantumTunnel.Main(String[])
```

Reference: https://github.com/commandlineparser/commandline/issues/848

Sorry for the hassle.